### PR TITLE
PreviewCrop: Does not throw if scaling happens before an image load

### DIFF
--- a/src/js/PreviewCrop.js
+++ b/src/js/PreviewCrop.js
@@ -12,7 +12,6 @@ export default View.extend({
 
   rendered() {
     this.on('moving', this._adjustImagePosition);
-    this.on('scaling', this._onImageScale);
     this.on('image-loaded', this.renderImage);
   },
 
@@ -26,6 +25,8 @@ export default View.extend({
 
     return this._loadImage(image)
     .then(image => {
+      this.on('scaling', this._onImageScale);
+
       this._drawNewImage({image, scale});
       this._adjustImagePosition({top, left});
       this._renderCanvas();

--- a/test/specs/PreviewCrop.js
+++ b/test/specs/PreviewCrop.js
@@ -34,6 +34,18 @@ describe('PreviewCrop', function() {
     expect(this.$canvas).toExist();
   });
 
+  it('does not throw if scaling happens before the image is loaded', function() {
+    const previewCrop = createPreviewCrop(this.$el);
+    expect(() => {
+      previewCrop.trigger('scaling', {
+        scale: 1,
+        left: 10,
+        top: 10
+      });
+    }).not.toThrow();
+    previewCrop.destroy();
+  });
+
   describe('when given an image', function() {
     it('renders a scaled down version', function() {
       expect(this.$canvas).toHaveCss({


### PR DESCRIPTION
Ref https://github.com/adobe-community/issues/issues/6685