### PR TITLE
Centralized slider styling

### DIFF
--- a/src/js/ZoomSlider.js
+++ b/src/js/ZoomSlider.js
@@ -11,14 +11,25 @@ export const ZoomSlider = View.extend({
   mustache: template,
 
   rendered() {
+    this._isEdge = this._detectEdge();
+
     this._$slider = this.$view.find('.js-scale-slider');
-    this._$slider.on('input', () => this.trigger('scale', this._currentScale()));
+    this._$slider.on('input', () => {
+      this.trigger('scale', this._currentScale());
+      this._colorSlider();
+    });
+
+    this._$slider.toggleClass('helicropter--edge-slider', this._isEdge);
+
+    this._sliderTrackBackgroudColor = this._model.sliderTrackBackgroundColor || '#cccccc';
+    this._sliderTrackActiveColor = this._model.sliderTrackActiveColor || '#0057ff';
 
     this.on({
       'image-loaded'({ scale, minScale }) {
         this._scaleMin = minScale;
         this._calculateScaleStep(scale);
         this._evaluateScalability();
+        this._colorSlider();
       },
 
       'set-crop-size'({ minScale }) {
@@ -30,6 +41,8 @@ export const ZoomSlider = View.extend({
         this._evaluateScalability();
       },
     });
+
+    this._colorSlider();
   },
 
   reset() {
@@ -44,6 +57,20 @@ export const ZoomSlider = View.extend({
   enable() {
     this.$view.removeClass('disabled');
     this._$slider.prop('disabled', false);
+  },
+
+  _detectEdge() {
+    return window.navigator.userAgent.indexOf('Edge') > -1;
+  },
+
+  _colorSlider() {
+    if (this._isEdge) {
+      return;
+    }
+
+    const value = this._$slider[0].value;
+
+    this._$slider.css('background', `linear-gradient(to right, ${this._sliderTrackActiveColor} ${value}%, ${this._sliderTrackBackgroudColor} ${value}%)`);
   },
 
   _evaluateScalability() {

--- a/src/templates/zoom-slider.mustache
+++ b/src/templates/zoom-slider.mustache
@@ -1,23 +1,111 @@
+<style>
+.helicropter--scale-slider {
+  -webkit-appearance: none;
+  margin: 10px 0;
+  height: 3px;
+  width: 100%;
+}
+
+.helicropter--edge-slider {
+  margin: 0;
+  height: 20px;
+}
+
+.helicropter--scale-slider::-moz-focus-outer {
+  border: 0;
+}
+
+.helicropter--scale-slider:focus {
+  outline: none;
+}
+
+.helicropter--scale-slider::-moz-range-track {
+  -moz-appearance: none;
+  background: transparent;
+}
+
+.helicropter--scale-slider::-moz-range-thumb {
+  border: 1px solid #ccc;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+  -moz-appearance: none;
+  box-shadow: 0px 1px 1px rgba(0,0,0,.2);
+  margin-top: 1px;
+}
+
+.helicropter--scale-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 3px;
+  cursor: pointer;
+  border-radius: 3px;
+  -moz-appearance: none;
+}
+
+.helicropter--scale-slider::-webkit-slider-thumb {
+  border: 1px solid #ccc;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+  -webkit-appearance: none;
+  top: 50%;
+  transform: translateY(-50%);
+  box-shadow: 0px 1px 1px rgba(0,0,0,.2);
+  margin-top: 1px;
+}
+
+.helicropter--scale-slider::-ms-tooltip {
+  display: none;
+}
+
+.helicropter--scale-slider::-ms-track {
+  border: inherit;
+  color: transparent;
+  background: #ccc;
+  margin: 0;
+  height: 3px;
+}
+
+.helicropter--scale-slider::-ms-fill-lower {
+  background: #0057ff;
+}
+
+.helicropter--scale-slider::-ms-thumb {
+  border: 1px solid #ccc;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+  box-shadow: 0px 1px 1px rgba(0,0,0,.2);
+  top: 0;
+  transform: none;
+}
+</style>
 <div class="slider-container">
-  <svg version="1.1" id="scaleImageSmall_x5F_16_x5F_lt-ou"
+  <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"  width="16" height="16"
      viewBox="0 0 16 16"
      style="enable-background:new 0 0 16 16;" xml:space="preserve" class="icon icon-image-resize-small">
-  <path class="st0" d="M3,12h10v-0.7287c-0.303-0.1903-1.8182-1.7054-2.3126-1.6865c-0.375,0.0266-1.7292,1.2729-2.1907,1.2729
+  <path d="M3,12h10v-0.7287c-0.303-0.1903-1.8182-1.7054-2.3126-1.6865c-0.375,0.0266-1.7292,1.2729-2.1907,1.2729
     c-0.4133,0-2.3334-2.2994-2.7927-2.2994C5.2446,8.5584,3,10.7291,3,11.0811V12z"/>
-  <circle class="st0" cx="11.6425" cy="5.8247" r="1.1251"/>
-  <path class="st0" d="M1,2v12h14V2H1z M14,13H2V3h12V13z"/>
+  <circle cx="11.6425" cy="5.8247" r="1.1251"/>
+  <path d="M1,2v12h14V2H1z M14,13H2V3h12V13z"/>
   </svg>
 
-  <input class="js-scale-slider" type="range" min=0 max=100 value=0 />
+  <input class="js-scale-slider helicropter--scale-slider" type="range" min=0 max=100 value=0 />
 
-  <svg version="1.1" id="scaleImageLarge_x5F_24_x5F_lt-ou"
+  <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"  width="24" height="24"
      viewBox="0 0 24 24"
      style="enable-background:new 0 0 24 24;" xml:space="preserve" class="icon icon-image-resize-large">
-  <path class="st0" d="M3,19l18-0.0509v-1.8566c-0.5625-0.4153-2.8125-3.7224-3.7303-3.6811
+  <path d="M3,19l18-0.0509v-1.8566c-0.5625-0.4153-2.8125-3.7224-3.7303-3.6811
     c-0.6961,0.0581-3.2098,2.7783-4.0665,2.7783c-0.7671,0-4.3314-5.0188-5.184-5.0188C7.1666,11.1709,3,15.909,3,16.6772V19z"/>
-  <circle class="st0" cx="16.0085" cy="8.0088" r="1.75"/>
-  <path class="st0" d="M1,3v18h22V3H1z M22,20H2V4h20V20z"/>
+  <circle cx="16.0085" cy="8.0088" r="1.75"/>
+  <path d="M1,3v18h22V3H1z M22,20H2V4h20V20z"/>
   </svg>
 </div>

--- a/test/specs/ZoomSlider.js
+++ b/test/specs/ZoomSlider.js
@@ -2,8 +2,15 @@ import { maxScale, ZoomSlider } from 'ZoomSlider';
 
 describe('ZoomSlider', function() {
   beforeEach(function() {
+    this.getExpectedSliderStyle = (value) => {
+      return `background: linear-gradient(to right, rgb(255, 255, 255) ${value}%, rgb(0, 0, 0) ${value}%);`;
+    };
+
     this.$el = affix('.js-zoom-slider-parent');
-    this.zoomSlider = new ZoomSlider();
+    this.zoomSlider = new ZoomSlider({
+      sliderTrackBackgroundColor: '#000',
+      sliderTrackActiveColor: '#fff',
+    });
     this.zoomSlider.render(this.$el);
   });
 
@@ -19,6 +26,15 @@ describe('ZoomSlider', function() {
     it('creates slider input binding', function(done) {
       this.zoomSlider.on('scale', done);
       this.zoomSlider.$view.find('.js-scale-slider').val(50).trigger('input');
+    });
+
+    it('colors _$slider initially', function() {
+      const value = 20;
+      const expectedStyle = this.getExpectedSliderStyle(value);
+
+      this.zoomSlider.$view.find('.js-scale-slider').val(value).trigger('input');
+
+      expect(this.zoomSlider.$view.find('.js-scale-slider')[0].getAttribute('style')).toEqual(expectedStyle);
     });
   });
 
@@ -166,6 +182,37 @@ describe('ZoomSlider', function() {
         });
 
         this.zoomSlider.trigger('set-crop-size', { minScale: 0.5 });
+      });
+    });
+
+    describe('Additional behaviors', function() {
+      it('colors _$slider when user slides the input range', function() {
+        const value = 50;
+        const expectedStyle = this.getExpectedSliderStyle(value);
+
+        this.zoomSlider.$view.find('.js-scale-slider').val(value).trigger('input');
+
+        expect(this.zoomSlider.$view.find('.js-scale-slider')[0].getAttribute('style')).toEqual(expectedStyle);
+      });
+
+      it('should add "helicropter--edge-slider" class if it is edge', function() {
+        this.zoomSlider = new ZoomSlider();
+
+        spyOn(this.zoomSlider, '_detectEdge').and.returnValue(true);
+
+        this.zoomSlider.render(this.$el);
+
+        expect(this.zoomSlider.$view.find('.js-scale-slider')).toHaveClass('helicropter--edge-slider');
+      });
+
+      it('should not add "helicropter--edge-slider" class if it is not edge', function() {
+        this.zoomSlider = new ZoomSlider();
+
+        spyOn(this.zoomSlider, '_detectEdge').and.returnValue(false);
+
+        this.zoomSlider.render(this.$el);
+
+        expect(this.zoomSlider.$view.find('.js-scale-slider')).not.toHaveClass('helicropter--edge-slider');
       });
     });
   });


### PR DESCRIPTION
Resolves adobe-community/issues/issues/24810
Resolves adobe-community/issues/issues/24146

## Note
This is a breaking change for Pro2UI and poet.
Rangeslider will need to be undone in both repo when bumping the version.
And override the slider style in each repo to their spec.

### Chrome
![screen shot 2018-06-19 at 4 02 47 pm](https://user-images.githubusercontent.com/20198642/41623502-fc7b2240-73e0-11e8-8d72-443add498a43.png)

### FF
![screen shot 2018-06-19 at 4 03 01 pm](https://user-images.githubusercontent.com/20198642/41623513-02bd3bde-73e1-11e8-82c1-00da0164d285.png)

### Safari
![screen shot 2018-06-19 at 4 03 08 pm](https://user-images.githubusercontent.com/20198642/41623519-07df1402-73e1-11e8-9de2-a95a8b599056.png)

### Edge
![screen shot 2018-06-19 at 4 02 06 pm](https://user-images.githubusercontent.com/20198642/41623533-0e3dfb1a-73e1-11e8-8982-881fdb8952f2.png)


